### PR TITLE
dnd: Don't call `Arc::get_mut`

### DIFF
--- a/dnd/src/platform/linux.rs
+++ b/dnd/src/platform/linux.rs
@@ -45,13 +45,7 @@ impl<T: mime::AsMimeTypes> AsMimeTypes for DataWrapper<T> {
 
 impl smithay_clipboard::dnd::RawSurface for DndSurface {
     unsafe fn get_ptr(&mut self) -> *mut c_void {
-        // XXX won't panic because this is only called once before it could be
-        // cloned
-        Arc::get_mut(&mut self.0)
-            .unwrap()
-            .window_handle()
-            .unwrap()
-            .get_ptr()
+        self.0.window_handle().unwrap().get_ptr()
     }
 }
 


### PR DESCRIPTION
The caller of `start_dnd` may also have a reference, so this can panic. Either the public API shouldn't take an `Arc` or this should be avoided.

There doesn't seem to be any reason this is needed anyway.